### PR TITLE
Run pre-commit in github actions

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -20,6 +20,8 @@ jobs:
         uses: actions/setup-python@v4.7.0
         with:
           python-version: "3.11"
+          cache: pip
+          cache-dependency-path: .pre-commit-config.yaml
 
       - uses: pre-commit/action@v3.0.0
 

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -1,0 +1,27 @@
+name: pre-commit
+
+on:
+  pull_request:
+    types: [opened, reopened, synchronize]
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+jobs:
+  pre-commit:
+    runs-on: ubuntu-latest
+    env:
+      FORCE_COLOR: "1"
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4.1.0
+
+      - name: Set up Python
+        uses: actions/setup-python@v4.7.0
+        with:
+          python-version: "3.11"
+
+      - uses: pre-commit/action@v3.0.0
+
+      - uses: pre-commit-ci/lite-action@v1.0.1
+        if: always()

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,9 +1,3 @@
-ci:
-    autofix_prs: false
-    autoupdate_schedule: weekly
-    autoupdate_commit_msg: 'chore(deps): pre-commit autoupdate'
-    skip: [check-jsonschema]
-
 repos:
 -   repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.4.0

--- a/meltano.yml
+++ b/meltano.yml
@@ -54,7 +54,7 @@ plugins:
   utilities:
   - name: sqlfluff
     variant: sqlfluff
-    pip_url: dbt-core~=1.5.0 dbt-duckdb~=1.5.2 sqlfluff>=2.1.0 sqlfluff-templater-dbt>=2.1.0
+    pip_url: dbt-core~=1.5.0 dbt-duckdb~=1.5.2 sqlfluff>=2.1.0 sqlfluff-templater-dbt>=2.1.0 duckdb<0.9.0
     settings:
     - name: path
       env: DBT_DUCKDB_PATH

--- a/meltano.yml
+++ b/meltano.yml
@@ -41,14 +41,14 @@ plugins:
     pip_url: target-jsonl
   - name: target-duckdb
     variant: jwills
-    pip_url: git+https://github.com/jwills/target-duckdb.git@main
+    pip_url: git+https://github.com/jwills/target-duckdb.git@main duckdb<0.9.0
     config:
       path: $DUCKDB_PATH
       default_target_schema: $MELTANO_EXTRACT__LOAD_SCHEMA
   transformers:
   - name: dbt-duckdb
     variant: jwills
-    pip_url: dbt-core~=1.5.0 dbt-duckdb~=1.5.2
+    pip_url: dbt-core~=1.5.0 dbt-duckdb~=1.5.2 duckdb<0.9.0
     config:
       path: $DUCKDB_PATH
   utilities:

--- a/meltano.yml
+++ b/meltano.yml
@@ -39,14 +39,12 @@ plugins:
   - name: target-jsonl
     variant: andyh1203
     pip_url: target-jsonl
-    target_schema: ''
   - name: target-duckdb
     variant: jwills
     pip_url: git+https://github.com/jwills/target-duckdb.git@main
     config:
       path: $DUCKDB_PATH
       default_target_schema: $MELTANO_EXTRACT__LOAD_SCHEMA
-    target_schema: $MELTANO_LOAD_DEFAULT_TARGET_SCHEMA
   transformers:
   - name: dbt-duckdb
     variant: jwills


### PR DESCRIPTION
- fix: Remove deprecated `target_schema` fields
- Run pre-commit in github actions
