### PR TITLE
chore: Bump duckdb to 0.10.2

### DIFF
--- a/evidence/package-lock.json
+++ b/evidence/package-lock.json
@@ -2270,14 +2270,6 @@
         "duckdb-async": "0.10.0"
       }
     },
-    "node_modules/@evidence-dev/duckdb/node_modules/duckdb-async": {
-      "version": "0.9.2",
-      "resolved": "https://registry.npmjs.org/duckdb-async/-/duckdb-async-0.9.2.tgz",
-      "integrity": "sha512-o33zBds2asp20/Mcw4ZJ1G9InD1TnOJ0U3XyIElLzim4sjlmgHc4R8NnLxdqZa/X9bjhzn364cA0XZ2fEKHPfw==",
-      "dependencies": {
-        "duckdb": "0.9.2"
-      }
-    },
     "node_modules/@evidence-dev/evidence": {
       "version": "32.0.1",
       "resolved": "https://registry.npmjs.org/@evidence-dev/evidence/-/evidence-32.0.1.tgz",
@@ -6637,14 +6629,22 @@
       "integrity": "sha512-LN1gO7+u9xjU5oEScGFKvXhYf7Y/empUIIEAGBs1LzUq/rg5duiDrkuH5A2lQGd5jfMOb9X9usDa2oVXwJ0U/Q=="
     },
     "node_modules/duckdb": {
-      "version": "0.9.2",
-      "resolved": "https://registry.npmjs.org/duckdb/-/duckdb-0.9.2.tgz",
-      "integrity": "sha512-POZ37Vf5cHVmk4W8z0PsdGi67VeQsr9HRrBbmivDt9AQ8C1XLESVE79facydbroNiqm7+n7fx6jqjyxyrBFYlQ==",
+      "version": "0.10.2",
+      "resolved": "https://registry.npmjs.org/duckdb/-/duckdb-0.10.2.tgz",
+      "integrity": "sha512-7UGLRp+zkAzE0AQjyUfOyEjuX7Xs3St452+ZtUSbQEE8DJjc6GUWscxYPm5XPe5fX4nL+Zy9lVMEss1Yuw74kA==",
       "hasInstallScript": true,
       "dependencies": {
         "@mapbox/node-pre-gyp": "^1.0.0",
         "node-addon-api": "^7.0.0",
         "node-gyp": "^9.3.0"
+      }
+    },
+    "node_modules/duckdb-async": {
+      "version": "0.10.2",
+      "resolved": "https://registry.npmjs.org/duckdb-async/-/duckdb-async-0.10.2.tgz",
+      "integrity": "sha512-Lf9MSnfcflyo8lpOfhDTOGsqkKeippJm2RZzry9sOG2Kvz+pDfLMuqhWQ4CQayud+Ktfs1L8DsrTIAsUCmbTlA==",
+      "dependencies": {
+        "duckdb": "0.10.2"
       }
     },
     "node_modules/duplexify": {

--- a/evidence/package.json
+++ b/evidence/package.json
@@ -20,8 +20,8 @@
     "@evidence-dev/evidence": "^32.0.1"
   },
   "overrides": {
-    "duckdb": "0.9.2",
-    "duckdb-async": "0.9.2",
+    "duckdb": "0.10.2",
+    "duckdb-async": "0.10.2",
     "jsonwebtoken": "9.0.0",
     "trim@<0.0.3": ">0.0.3",
     "sqlite3": "5.1.5"

--- a/meltano.yml
+++ b/meltano.yml
@@ -61,7 +61,7 @@ plugins:
     pip_url: target-jsonl==0.1.4
   - name: target-duckdb
     variant: jwills
-    pip_url: git+https://github.com/jwills/target-duckdb.git@main duckdb==0.10.2
+    pip_url: git+https://github.com/jwills/target-duckdb.git@refs/pull/43/head duckdb==0.10.2
     config:
       path: $DUCKDB_PATH
       default_target_schema: $MELTANO_EXTRACT__LOAD_SCHEMA

--- a/meltano.yml
+++ b/meltano.yml
@@ -61,20 +61,20 @@ plugins:
     pip_url: target-jsonl==0.1.4
   - name: target-duckdb
     variant: jwills
-    pip_url: git+https://github.com/jwills/target-duckdb.git@main duckdb==0.9.2
+    pip_url: git+https://github.com/jwills/target-duckdb.git@main duckdb==0.10.2
     config:
       path: $DUCKDB_PATH
       default_target_schema: $MELTANO_EXTRACT__LOAD_SCHEMA
   transformers:
   - name: dbt-duckdb
     variant: jwills
-    pip_url: dbt-core~=1.7.0 dbt-duckdb~=1.7.0 duckdb==0.9.2
+    pip_url: dbt-core~=1.7.0 dbt-duckdb~=1.7.0 duckdb==0.10.2
     config:
       path: $DUCKDB_PATH
   utilities:
   - name: sqlfluff
     variant: sqlfluff
-    pip_url: dbt-core~=1.7.0 dbt-duckdb~=1.7.0 sqlfluff>=3.0.6 sqlfluff-templater-dbt>=3.0.6 duckdb==0.9.2
+    pip_url: dbt-core~=1.7.0 dbt-duckdb~=1.7.0 sqlfluff>=3.0.6 sqlfluff-templater-dbt>=3.0.6 duckdb==0.10.2
     settings:
     - name: path
       env: DBT_DUCKDB_PATH

--- a/pkl/main.pkl
+++ b/pkl/main.pkl
@@ -42,7 +42,9 @@ output {
         new plugin.Loader {
           name = "target-duckdb"
           variant = "jwills"
-          pip_url = "git+https://github.com/jwills/target-duckdb.git@main duckdb==0.10.2"
+          // Use a PyPI release when available
+          // https://github.com/jwills/target-duckdb/pull/43
+          pip_url = "git+https://github.com/jwills/target-duckdb.git@refs/pull/43/head duckdb==0.10.2"
           config = new Mapping {
             ["path"] = "$DUCKDB_PATH"
             ["default_target_schema"] = "$MELTANO_EXTRACT__LOAD_SCHEMA"


### PR DESCRIPTION
Related:

* Blocked by https://github.com/jwills/target-duckdb/issues/40
* Closes https://github.com/edgarrmondragon/meltano-dogfood/issues/296
* https://github.com/jwills/target-duckdb/pull/43