### PR TITLE
Bump duckdb to 1.3.0

### DIFF
--- a/meltano.yml
+++ b/meltano.yml
@@ -11,7 +11,7 @@ ff:
   plugin_locks_required: true
 env:
   SINGER_SDK_LOG_CONFIG: logging/singer_logging.yaml
-  UV_EXCLUDE_NEWER: 2025-05-15
+  UV_EXCLUDE_NEWER: 2025-05-21
 plugins:
   extractors:
   - name: tap-getpocket
@@ -68,19 +68,19 @@ plugins:
     pip_url: target-jsonl==0.1.4
   - name: target-duckdb
     variant: jwills
-    pip_url: duckdb==1.2.2 target-duckdb==0.8.0
+    pip_url: duckdb==1.3.0 target-duckdb==0.8.0
     config:
       path: $DUCKDB_PATH
       default_target_schema: $MELTANO_EXTRACT__LOAD_SCHEMA
   utilities:
   - name: dbt-duckdb
     variant: jwills
-    pip_url: dbt-core~=1.10.0b1 dbt-duckdb~=1.9.1 duckdb==1.2.2 meltano-dbt-ext~=0.3.0
+    pip_url: dbt-core~=1.10.0b1 dbt-duckdb~=1.9.1 duckdb==1.3.0 meltano-dbt-ext~=0.3.0
     config:
       path: $DUCKDB_PATH
   - name: sqlfluff
     variant: sqlfluff
-    pip_url: dbt-core~=1.10.0b1 dbt-duckdb~=1.9.1 sqlfluff~=3.3 sqlfluff-templater-dbt~=3.3 duckdb==1.2.2
+    pip_url: dbt-core~=1.10.0b1 dbt-duckdb~=1.9.1 sqlfluff~=3.3 sqlfluff-templater-dbt~=3.3 duckdb==1.3.0
     settings:
     - name: path
       env: DBT_DUCKDB_PATH

--- a/pkl/main.pkl
+++ b/pkl/main.pkl
@@ -16,7 +16,7 @@ output {
     python = "python3.13"
     env = new Mapping {
       ["SINGER_SDK_LOG_CONFIG"] = "logging/singer_logging.yaml"
-      ["UV_EXCLUDE_NEWER"] = "2025-05-15"
+      ["UV_EXCLUDE_NEWER"] = "2025-05-21"
     }
     ff = new project.FeatureFlags {
       plugin_locks_required = true
@@ -45,7 +45,7 @@ output {
         new plugin.Loader {
           name = "target-duckdb"
           variant = "jwills"
-          pip_url = "duckdb==1.2.2 target-duckdb==0.8.0"
+          pip_url = "duckdb==1.3.0 target-duckdb==0.8.0"
           config = new Mapping {
             ["path"] = "$DUCKDB_PATH"
             ["default_target_schema"] = "$MELTANO_EXTRACT__LOAD_SCHEMA"
@@ -56,7 +56,7 @@ output {
         new plugin.Utility {
           name = "dbt-duckdb"
           variant = "jwills"
-          pip_url = "dbt-core~=1.10.0b1 dbt-duckdb~=1.9.1 duckdb==1.2.2 meltano-dbt-ext~=0.3.0"
+          pip_url = "dbt-core~=1.10.0b1 dbt-duckdb~=1.9.1 duckdb==1.3.0 meltano-dbt-ext~=0.3.0"
           config = new Mapping {
             ["path"] = "$DUCKDB_PATH"
           }
@@ -64,7 +64,7 @@ output {
         new plugin.Utility {
           name = "sqlfluff"
           variant = "sqlfluff"
-          pip_url = "dbt-core~=1.10.0b1 dbt-duckdb~=1.9.1 sqlfluff~=3.3 sqlfluff-templater-dbt~=3.3 duckdb==1.2.2"
+          pip_url = "dbt-core~=1.10.0b1 dbt-duckdb~=1.9.1 sqlfluff~=3.3 sqlfluff-templater-dbt~=3.3 duckdb==1.3.0"
           settings = List(
             new plugin.Setting {
               name = "path"


### PR DESCRIPTION
MotherDuck doesn't support 1.3.0 yet.

- https://duckdb.org/2025/05/21/announcing-duckdb-130
- https://motherduck.com/docs/about-motherduck/release-notes/#may-29-2025