### PR TITLE
Remove public setting from vercel.json

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,6 +1,5 @@
 {
   "version": 2,
-  "public": false,
   "github": {
     "enabled": false
   }


### PR DESCRIPTION
> This option is deprecated and no longer enables public access to deployment source or build logs. Deployments always keep [source view](https://vercel.com/docs/builds/build-features#source-view) and [logs view](https://vercel.com/docs/builds/build-features#logs-view) protected behind authentication.
